### PR TITLE
/v1 returns 404, should be /v1a

### DIFF
--- a/summarizer/apidoc.md
+++ b/summarizer/apidoc.md
@@ -7,7 +7,7 @@
   
 * **Endoint**
 
-  `/api/ext/summarizer/v1`
+  `/api/ext/summarizer/v1a`
   
   The base URL is https://sassbook.com.
 


### PR DESCRIPTION
When calling `endpoint` it fails with 404, `/v1a` works