### PR TITLE
Update API endpoint

### DIFF
--- a/summarizer/apidoc.md
+++ b/summarizer/apidoc.md
@@ -7,7 +7,7 @@
   
 * **Endoint**
 
-  `/api/ext/summarizer/v1`
+  `/api/ext/summarize/v1`
   
   The base URL is https://sassbook.com.
 


### PR DESCRIPTION
Updated to /api/ext/summarize/v1.

This used to be /api/ext/summarizer/v1. Both continue to work to avoid any disruption. Code samples already reflect the updated path.